### PR TITLE
add native asset (ETH) support

### DIFF
--- a/contracts/ERC20PrivacyPool.sol
+++ b/contracts/ERC20PrivacyPool.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+import "./PrivacyPool.sol";
+
+contract ERC20PrivacyPool is PrivacyPool {
+  IERC20 public immutable token;
+
+  /**
+    @dev The constructor
+    @param _verifier2 the address of SNARK verifier for 2 inputs
+    @param _levels hight of the commitments merkle tree
+    @param _hasher hasher address for the merkle tree
+    @param _token token address for the pool
+  */
+  constructor(
+    IVerifier _verifier2,
+    uint32 _levels,
+    address _hasher,
+    IERC20 _token,
+    uint256 _maximumDepositAmount
+  ) PrivacyPool(_verifier2, _levels, _hasher, _maximumDepositAmount) {
+    token = _token;
+  }
+
+  function _processDeposit(ExtData memory _extData) internal override {
+    require(msg.value == 0, "ETH is not accepted for ERC20 pool");
+    if (_extData.extAmount > 0) {
+      require(uint256(_extData.extAmount) <= maximumDepositAmount, "amount is larger than maximumDepositAmount");
+      token.transferFrom(msg.sender, address(this), uint256(_extData.extAmount));
+    }
+  }
+
+  function _processWithdraw(ExtData memory _extData) internal override {
+    if (_extData.extAmount < 0) {
+      require(_extData.recipient != address(0), "Can't withdraw to zero address");
+      token.transfer(_extData.recipient, uint256(-_extData.extAmount));
+      emit NewWithdrawal(_extData.recipient, uint256(-_extData.extAmount), _extData.membershipProofURI);
+    }
+    if (_extData.fee > 0) {
+      token.transfer(_extData.relayer, _extData.fee);
+    }
+  }
+  
+}

--- a/contracts/ETHPrivacyPool.sol
+++ b/contracts/ETHPrivacyPool.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+import "./PrivacyPool.sol";
+import "solmate/src/utils/SafeTransferLib.sol";
+
+contract ETHPrivacyPool is PrivacyPool {
+  
+  /**
+    @dev The constructor
+    @param _verifier2 the address of SNARK verifier for 2 inputs
+    @param _levels hight of the commitments merkle tree
+    @param _hasher hasher address for the merkle tree
+  */
+  constructor(
+    IVerifier _verifier2,
+    uint32 _levels,
+    address _hasher,
+    uint256 _maximumDepositAmount
+  ) PrivacyPool(_verifier2, _levels, _hasher, _maximumDepositAmount) {}
+
+  function _processDeposit(ExtData memory _extData) internal override {
+    if (_extData.extAmount > 0) {
+      require(msg.value == uint256(_extData.extAmount), "Invalid amount");
+      require(uint256(_extData.extAmount) <= maximumDepositAmount, "amount is larger than maximumDepositAmount");
+    }
+  }
+
+  function _processWithdraw(ExtData memory _extData) internal override {
+    if (_extData.extAmount < 0) {
+      require(_extData.recipient != address(0), "Can't withdraw to zero address");
+      SafeTransferLib.safeTransferETH(_extData.recipient, uint256(-_extData.extAmount));
+      emit NewWithdrawal(_extData.recipient, uint256(-_extData.extAmount), _extData.membershipProofURI);
+    }
+    if (_extData.fee > 0) {
+      SafeTransferLib.safeTransferETH(_extData.relayer, _extData.fee);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "omnibridge": "git+https://github.com/peppersec/omnibridge.git#30081f7a735eb03c9d6821a9617cc28efe71a682",
     "prompt-sync": "^4.2.0",
     "snarkjs": "git+https://github.com/tornadocash/snarkjs.git#f37f146948f3b28086493e71512006b030588fc2",
+    "solmate": "^6.2.0",
     "tmp-promise": "^3.0.2",
     "typechain": "^5.1.2"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -34,7 +34,7 @@ async function balance({ tornadoPool, keypair }) {
   return utxos.reduce((sum, x) => sum.add(x.amount), BigNumber.from(0))
 }
 
-async function transact({ tornadoPool, keypair, amount, recipient = 0, allowlist = null }) {
+async function transact({ tornadoPool, keypair, amount, msgValue = 0, recipient = 0, allowlist = null }) {
   let inputs = await getUtxos({ tornadoPool, keypair })
   if (inputs.length > 2) {
     throw new Error('Too many utxos, contact support')
@@ -84,11 +84,11 @@ async function transact({ tornadoPool, keypair, amount, recipient = 0, allowlist
       throw new Error('Proof is not valid')
     }
   }
-  return await transaction({ tornadoPool, inputs, outputs, recipient, membershipProofURI: '' })
+  return await transaction({ tornadoPool, inputs, outputs, recipient, membershipProofURI: '', msgValue })
 }
 
-async function deposit({ tornadoPool, keypair, amount }) {
-  return await transact({ tornadoPool, keypair, amount })
+async function deposit({ tornadoPool, keypair, amount, msgValue = 0}) {
+  return await transact({ tornadoPool, keypair, amount, msgValue })
 }
 
 async function withdraw({ tornadoPool, keypair, amount, recipient, allowlist = null }) {

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,7 @@ async function prepareTransaction({
   recipient = 0,
   relayer = 0,
   membershipProofURI = '',
+  msgValue = 0,
 }) {
   if (inputs.length > 16 || outputs.length > 2) {
     throw new Error('Incorrect inputs/outputs count')
@@ -122,17 +123,19 @@ async function prepareTransaction({
   return {
     args,
     extData,
+    msgValue,
   }
 }
 
 async function transaction({ tornadoPool, ...rest }) {
-  const { args, extData } = await prepareTransaction({
+  const { args, extData, msgValue } = await prepareTransaction({
     tornadoPool,
     ...rest,
   })
 
   const receipt = await tornadoPool.transact(args, extData, {
     gasLimit: 2e6,
+    value: msgValue,
   })
   return await receipt.wait()
 }

--- a/test/erc20.full.test.js
+++ b/test/erc20.full.test.js
@@ -1,0 +1,249 @@
+const hre = require('hardhat')
+const { ethers, waffle } = hre
+const { loadFixture } = waffle
+const { expect } = require('chai')
+const { utils } = ethers
+
+const Utxo = require('../src/utxo')
+const { transaction, prepareTransaction, buildMerkleTree } = require('../src/index')
+const { toFixedHex, poseidonHash } = require('../src/utils')
+const { Keypair } = require('../src/keypair')
+
+const { getUtxos, deposit, withdraw, balance } = require('../src/cli')
+
+const MERKLE_TREE_HEIGHT = 23
+const MAXIMUM_DEPOSIT_AMOUNT = utils.parseEther(process.env.MAXIMUM_DEPOSIT_AMOUNT || '1')
+
+describe('ERC20 Privacy Pool', function () {
+  this.timeout(20000)
+
+  async function deploy(contractName, ...args) {
+    const Factory = await ethers.getContractFactory(contractName)
+    const instance = await Factory.deploy(...args)
+    return instance.deployed()
+  }
+
+  async function fixture() {
+    require('../scripts/compileHasher')
+    const [sender] = await ethers.getSigners()
+    const verifier2 = await deploy('Verifier2')
+    const hasher = await deploy('Hasher')
+    const token = await deploy('WETH', 'Wrapped ETH', 'WETH')
+    await token.deposit({ value: utils.parseEther('3') })
+
+    const tornadoPool = await deploy(
+      'ERC20PrivacyPool',
+      verifier2.address,
+      MERKLE_TREE_HEIGHT,
+      hasher.address,
+      token.address,
+      MAXIMUM_DEPOSIT_AMOUNT,
+    )
+
+    await token.approve(tornadoPool.address, utils.parseEther('10000'))
+
+    return { tornadoPool, token, sender }
+  }
+
+  it('encrypt -> decrypt should work', () => {
+    const data = Buffer.from([0xff, 0xaa, 0x00, 0x01])
+    const keypair = new Keypair()
+
+    const ciphertext = keypair.encrypt(data)
+    const result = keypair.decrypt(ciphertext)
+    expect(result).to.be.deep.equal(data)
+  })
+
+  it('constants check', async () => {
+    const { tornadoPool } = await loadFixture(fixture)
+    const maxFee = await tornadoPool.MAX_FEE()
+    const maxExtAmount = await tornadoPool.MAX_EXT_AMOUNT()
+    const fieldSize = await tornadoPool.FIELD_SIZE()
+
+    expect(maxExtAmount.add(maxFee)).to.be.lt(fieldSize)
+  })
+
+  it('should deposit, transact and withdraw', async function () {
+    const { tornadoPool, token } = await loadFixture(fixture)
+
+    // Alice deposits into tornado pool
+    const aliceDepositAmount = utils.parseEther('0.1')
+    const aliceDepositUtxo = new Utxo({ amount: aliceDepositAmount })
+    await transaction({ tornadoPool, outputs: [aliceDepositUtxo] })
+
+    // Bob gives Alice address to send some eth inside the shielded pool
+    const bobKeypair = new Keypair() // contains private and public keys
+    const bobAddress = bobKeypair.address() // contains only public key
+
+    // Alice sends some funds to Bob
+    const bobSendAmount = utils.parseEther('0.06')
+    const bobSendUtxo = new Utxo({ amount: bobSendAmount, keypair: Keypair.fromString(bobAddress) })
+    const aliceChangeUtxo = new Utxo({
+      amount: aliceDepositAmount.sub(bobSendAmount),
+      keypair: aliceDepositUtxo.keypair,
+    })
+    await transaction({ tornadoPool, inputs: [aliceDepositUtxo], outputs: [bobSendUtxo, aliceChangeUtxo] })
+
+    // Bob parses chain to detect incoming funds
+    const filter = tornadoPool.filters.NewCommitment()
+    const fromBlock = await ethers.provider.getBlock()
+    const events = await tornadoPool.queryFilter(filter, fromBlock.number)
+    let bobReceiveUtxo
+    try {
+      bobReceiveUtxo = Utxo.decrypt(bobKeypair, events[0].args.encryptedOutput, events[0].args.index)
+    } catch (e) {
+      // we try to decrypt another output here because it shuffles outputs before sending to blockchain
+      bobReceiveUtxo = Utxo.decrypt(bobKeypair, events[1].args.encryptedOutput, events[1].args.index)
+    }
+    expect(bobReceiveUtxo.amount).to.be.equal(bobSendAmount)
+
+    // Bob withdraws a part of his funds from the shielded pool
+    const bobWithdrawAmount = utils.parseEther('0.05')
+    const bobEthAddress = '0xDeaD00000000000000000000000000000000BEEf'
+    const bobChangeUtxo = new Utxo({ amount: bobSendAmount.sub(bobWithdrawAmount), keypair: bobKeypair })
+    await transaction({
+      tornadoPool,
+      inputs: [bobReceiveUtxo],
+      outputs: [bobChangeUtxo],
+      recipient: bobEthAddress,
+    })
+
+    const bobBalance = await token.balanceOf(bobEthAddress)
+    expect(bobBalance).to.be.equal(bobWithdrawAmount)
+  })
+
+  it('should be compliant', async function () {
+    // basically verifier should check if a commitment and a nullifier hash are on chain
+    const { tornadoPool } = await loadFixture(fixture)
+    const aliceDepositAmount = utils.parseEther('0.07')
+    const aliceDepositUtxo = new Utxo({ amount: aliceDepositAmount })
+    const [sender] = await ethers.getSigners()
+
+    const { args, extData } = await prepareTransaction({
+      tornadoPool,
+      outputs: [aliceDepositUtxo],
+    })
+    const receipt = await tornadoPool.transact(args, extData, {
+      gasLimit: 2e6,
+    })
+    await receipt.wait()
+
+    // withdrawal
+    await transaction({
+      tornadoPool,
+      inputs: [aliceDepositUtxo],
+      outputs: [],
+      recipient: sender.address,
+    })
+
+    const tree = await buildMerkleTree({ tornadoPool })
+    const commitment = aliceDepositUtxo.getCommitment()
+    const index = tree.indexOf(toFixedHex(commitment)) // it's the same as merklePath and merklePathIndexes and index in the tree
+    aliceDepositUtxo.index = index
+    const nullifier = aliceDepositUtxo.getNullifier()
+
+    // commitment = hash(amount, pubKey, blinding)
+    // nullifier = hash(commitment, merklePath, sign(merklePath, privKey))
+    const dataForVerifier = {
+      commitment: {
+        amount: aliceDepositUtxo.amount,
+        pubkey: aliceDepositUtxo.keypair.pubkey,
+        blinding: aliceDepositUtxo.blinding,
+      },
+      nullifier: {
+        commitment,
+        merklePath: index,
+        signature: aliceDepositUtxo.keypair.sign(commitment, index),
+      },
+    }
+
+    // generateReport(dataForVerifier) -> compliance report
+    // on the verifier side we compute commitment and nullifier and then check them onchain
+    const commitmentV = poseidonHash([...Object.values(dataForVerifier.commitment)])
+    const nullifierV = poseidonHash([
+      commitmentV,
+      dataForVerifier.nullifier.merklePath,
+      dataForVerifier.nullifier.signature,
+    ])
+
+    expect(commitmentV).to.be.equal(commitment)
+    expect(nullifierV).to.be.equal(nullifier)
+    expect(await tornadoPool.nullifierHashes(nullifierV)).to.be.equal(true)
+    // expect commitmentV present onchain (it will be in NewCommitment events)
+
+    // in report we can see the tx with NewCommitment event (this is how alice got money)
+    // and the tx with NewNullifier event is where alice spent the UTXO
+  })
+
+  it('should deposit with single keypair', async function () {
+    const { tornadoPool } = await loadFixture(fixture)
+    const aliceDepositAmount = utils.parseEther('0.07')
+
+    const aliceKeypair = new Keypair() // contains private and public keys
+
+    await deposit({
+      provider: ethers.provider,
+      tornadoPool,
+      keypair: aliceKeypair,
+      amount: aliceDepositAmount,
+    })
+
+    const filter = tornadoPool.filters.NewCommitment()
+    const fromBlock = await ethers.provider.getBlock()
+    const events = await tornadoPool.queryFilter(filter, fromBlock.number)
+    const aliceReceiveUtxo1 = Utxo.decrypt(aliceKeypair, events[0].args.encryptedOutput, events[0].args.index)
+    const aliceReceiveUtxo2 = Utxo.decrypt(aliceKeypair, events[1].args.encryptedOutput, events[1].args.index)
+    expect(aliceReceiveUtxo1.amount.add(aliceReceiveUtxo2.amount)).to.be.equal(aliceDepositAmount)
+    const aliceUtxos = await getUtxos({ provider: ethers.provider, tornadoPool, keypair: aliceKeypair })
+    expect(aliceUtxos.length).to.be.equal(1)
+    expect(aliceUtxos[0].amount).to.be.equal(aliceDepositAmount)
+  })
+
+  it('should deposit and withdraw with single keypair', async function () {
+    const { tornadoPool } = await loadFixture(fixture)
+    const aliceDepositAmount1 = utils.parseEther('0.03')
+    const aliceDepositAmount2 = utils.parseEther('0.04')
+    const aliceWithdrawAmount = utils.parseEther('0.05')
+    const bobEthAddress = '0xDeaD00000000000000000000000000000000BEEf'
+
+    const aliceKeypair = new Keypair() // contains private and public keys
+
+    await deposit({
+      provider: ethers.provider,
+      tornadoPool,
+      keypair: aliceKeypair,
+      amount: aliceDepositAmount1,
+    })
+    expect(await balance({ provider: ethers.provider, tornadoPool, keypair: aliceKeypair })).to.be.equal(
+      aliceDepositAmount1,
+    )
+    await deposit({
+      provider: ethers.provider,
+      tornadoPool,
+      keypair: aliceKeypair,
+      amount: aliceDepositAmount2,
+    })
+    expect(await balance({ provider: ethers.provider, tornadoPool, keypair: aliceKeypair })).to.be.equal(
+      aliceDepositAmount1.add(aliceDepositAmount2),
+    )
+    await withdraw({
+      provider: ethers.provider,
+      tornadoPool,
+      keypair: aliceKeypair,
+      amount: aliceWithdrawAmount,
+      recipient: bobEthAddress,
+    })
+    expect(await balance({ provider: ethers.provider, tornadoPool, keypair: aliceKeypair })).to.be.equal(
+      aliceDepositAmount1.add(aliceDepositAmount2).sub(aliceWithdrawAmount),
+    )
+  })
+
+  it('should not be able to deposit with positive msg.value', async function () {
+    const { tornadoPool } = await loadFixture(fixture)
+    const aliceDepositAmount = utils.parseEther('0.01')
+    const aliceDepositUtxo = new Utxo({ amount: aliceDepositAmount })
+    await expect(
+      transaction({ tornadoPool, outputs: [aliceDepositUtxo] , msgValue: utils.parseEther('0.01')})
+    ).to.be.revertedWith('ETH is not accepted for ERC20 pool')
+  })
+})

--- a/test/poi.test.js
+++ b/test/poi.test.js
@@ -35,7 +35,7 @@ describe('ProofOfInnocence', function () {
 
     /** @type {TornadoPool} */
     const tornadoPool = await deploy(
-      'PrivacyPool',
+      'ERC20PrivacyPool',
       verifier2.address,
       MERKLE_TREE_HEIGHT,
       hasher.address,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8696,6 +8696,11 @@ solidity-comments-extractor@^0.0.7:
   resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
   integrity sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==
 
+solmate@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/solmate/-/solmate-6.2.0.tgz#edd29b5f3d6faafafdcf65fe4d1d959b4841cfa8"
+  integrity sha512-AM38ioQ2P8zRsA42zenb9or6OybRjOLXIu3lhIT8rhddUuduCt76pUEuLxOIg9GByGojGz+EbpFdCB6B+QZVVA==
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"


### PR DESCRIPTION
Changes:
- Made `PrivacyPool` abstract, which `ERC20PrivacyPool`  and `ETHPrivacyPool` inherits from and apply their respective logic
- Installed `solmate` for ETH transfers 
- Changed `cli.js` and `index.js` so that the tests can send ETH with the transactions, which is necessary for `ETHPrivacyPool`
- Copied full test into ERC20 full test and ETH full test, and added a scenario for the existing ERC20 full test which tests the case where ether is sent into the ERC20 pool mistakenly and should revert
- Modified existing ERC20 tests into ETH test and added a scenario in which the `_extData.extAmount` deposit amount does not match with supplied `msg.value` which should revert